### PR TITLE
Add ollama example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The skill utilizes the `~/.config/mycroft/skills/skill-ovos-fallback-chatgpt.ope
 {
   "key": "sk-XXXYYYZZZAAABBB123",
   "model": "gpt-3.5-turbo",
-  "persona": "You are a helpful voice assistant with a friendly tone and fun sense of humor",
+  "persona": "You are a helpful voice assistant with a friendly tone and fun sense of humor. You respond in 40 words or fewer.",
   "enable_memory": true,
   "memory_size": 15,
   "__mycroft_skill_firstrun": false
@@ -57,11 +57,16 @@ The skill utilizes the `~/.config/mycroft/skills/skill-ovos-fallback-chatgpt.ope
 
 ### Configuration for use with Local AI
 
+You can use a llama-based local AI to power this skill. Make sure you update the "model" param and put any arbitrary key into the key param.
+
+If you're running a local ollama or llama.cpp instance, you can use `http://localhost:11434/v1` as the api_url. 
+
 ```json
 {
   "api_url": "https://llama.smartgic.io/v1",
   "key": "sk-xxx",
-  "persona": "You are a helpful voice assistant with a friendly tone and fun sense of humor",
+  "model": "llama3:latest",
+  "persona": "You are a helpful voice assistant with a friendly tone and fun sense of humor. You respond in 40 words or fewer.",
   "enable_memory": true,
   "memory_size": 15,
   "name": "A.I.",
@@ -69,6 +74,12 @@ The skill utilizes the `~/.config/mycroft/skills/skill-ovos-fallback-chatgpt.ope
   "__mycroft_skill_firstrun": false
 }
 ```
+
+## See also
+
+- [OVOS OpenAI Persona Plugin](https://github.com/OpenVoiceOS/ovos-solver-openai-persona-plugin) - The underlying plugin that powers this skill's integration with various AI models.
+- [Ollama OpenAI Compatibility](https://ollama.com/blog/openai-compatibility).
+- [Other compatible servers in the OVOS docs](https://openvoiceos.github.io/ovos-technical-manual/202-persona_server/#compatible-projects)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Under skill settings (`.config/mycroft/skills/skill-ovos-fallback-chatgpt.openvo
 | `name`          | `Chat G.P.T.`                                                           | Name to give to the AI assistant                                                      |
 | `confirmation`  | `true`                                                                  | Spoken confirmation will be triggered when a request is sent to the AI                |
 
-When using a local AI server instead of OpenAI, the `api_url`has to redirect to an alternative/local server compatible with OpenAI API. When using local AI, the `key` can be anything, but it has to exist. Read more about it in the OVOS technical manual, page [persona server](https://openvoiceos.github.io/ovos-technical-manual/persona_server/#compatible-projects)
-
 The default persona is `You are a helpful voice assistant with a friendly tone and fun sense of humor. You respond in 40 words or fewer.`
 
 ## Configurations
@@ -57,11 +55,9 @@ The skill utilizes the `~/.config/mycroft/skills/skill-ovos-fallback-chatgpt.ope
 
 ### Configuration for use with Local AI
 
-You can use a local AI to power this skill instead of Chat GPT. See some of the options in the "See also" section below.
+When using a local AI server instead of OpenAI, the `api_url`has to redirect to an alternative/local server compatible with OpenAI API. When using local AI, the `key` can be anything, but it has to exist. Read more about it in the OVOS technical manual, page [persona server](https://openvoiceos.github.io/ovos-technical-manual/persona_server/#compatible-projects)
 
-Hint: If you're running a llama server, you can use `http://localhost:11434/v1` as the api_url. 
-
-Hint: the skill currently requires the key param to be present; put any string into this parameter for local AI
+Hint: If you're running an ollama server, you can use `http://localhost:11434/v1` as the api_url. 
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The skill utilizes the `~/.config/mycroft/skills/skill-ovos-fallback-chatgpt.ope
 
 ### Configuration for use with Local AI
 
-When using a local AI server instead of OpenAI, the `api_url`has to redirect to an alternative/local server compatible with OpenAI API. When using local AI, the `key` can be anything, but it has to exist. Read more about it in the OVOS technical manual, page [persona server](https://openvoiceos.github.io/ovos-technical-manual/persona_server/#compatible-projects)
+When using a local AI server instead of OpenAI, the `api_url` has to redirect to an alternative/local server compatible with OpenAI API. When using local AI, the `key` can be anything, but it has to exist. Read more about it in the OVOS technical manual, page [persona server](https://openvoiceos.github.io/ovos-technical-manual/persona_server/#compatible-projects)
 
 Hint: If you're running an ollama server, you can use `http://localhost:11434/v1` as the api_url. 
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ The skill utilizes the `~/.config/mycroft/skills/skill-ovos-fallback-chatgpt.ope
 
 ### Configuration for use with Local AI
 
-You can use a llama-based local AI to power this skill. Make sure you update the "model" param and put any arbitrary key into the key param.
+You can use a local AI to power this skill instead of Chat GPT. See some of the options in the "See also" section below.
 
-If you're running a local ollama or llama.cpp instance, you can use `http://localhost:11434/v1` as the api_url. 
+Hint: If you're running a llama server, you can use `http://localhost:11434/v1` as the api_url. 
+
+Hint: the skill currently requires the key param to be present; put any string into this parameter for local AI
 
 ```json
 {


### PR DESCRIPTION
I just spent a while trying to understand how to use a locally-running ollama instance, so adding some documentation to the README that would have saved me some time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded persona description in the OpenAI configuration example, including a directive on response length.
  - Updated configuration example for Local AI, reflecting the new model specification (`llama3:latest`) and API URL.
  - Added a new section clarifying the use of a local AI.
  - Introduced a "See also" section with links to relevant resources, including the OVOS OpenAI Persona Plugin and compatibility information for Ollama.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->